### PR TITLE
[Unity] correctly remove Protobuffer directory

### DIFF
--- a/Barracuda/Runtime/Plugins/ProtoBuffer.meta
+++ b/Barracuda/Runtime/Plugins/ProtoBuffer.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 63044871e4b2444f58fc1f851449f1ab
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Correctly remove Protobuffer directory removed in 2b2c40e145df95015a5992cb3b5381600b184231 by also removing Unity .meta file for it.

Otherwise, Unity will always recreate the directory.